### PR TITLE
Implement real delete functionality for RAG engine

### DIFF
--- a/src/rag/api/routes/rag.py
+++ b/src/rag/api/routes/rag.py
@@ -228,7 +228,8 @@ async def delete(
 
     Raises:
         404: Collection does not exist
-        501: Not implemented (placeholder)
+        400: Invalid filter criteria
+        500: Delete operation failed
     """
     logger.info(
         f"Delete request for collection '{request.collection}' "
@@ -240,13 +241,38 @@ async def delete(
     if not _collection_exists(request.collection):
         raise IndexNotFoundError(f"Collection '{request.collection}' does not exist")
 
-    # TODO: Implement deletion logic
-    # For now, return a not implemented error
-    raise HTTPException(
-        status_code=501,
-        detail="Delete operation not yet implemented. "
-        "This will be available in a future update.",
-    )
+    # Validate filter criteria
+    if not request.filter:
+        raise InvalidRequestError("Filter criteria cannot be empty")
+
+    try:
+        # Load the vector DB
+        index_path = _get_index_path(request.collection)
+        vdb = VectorDB(str(index_path))
+
+        # Perform deletion
+        deleted_count = vdb.delete(request.filter)
+
+        # Persist changes if any deletions occurred
+        if deleted_count > 0:
+            vdb.savez(str(index_path))
+
+        logger.info(
+            f"Deleted {deleted_count} chunks from collection '{request.collection}' "
+            f"[request_id={x_request_id}]"
+        )
+
+        return DeleteResponse(
+            deleted_count=deleted_count,
+            collection=request.collection,
+        )
+
+    except Exception as e:
+        logger.error(
+            f"Delete failed for collection '{request.collection}': {e} "
+            f"[request_id={x_request_id}]"
+        )
+        raise HTTPException(status_code=500, detail=f"Delete operation failed: {str(e)}")
 
 
 @router.get("/stats", response_model=StatsResponse, tags=["RAG"])

--- a/src/rag/retrieval/vdb.py
+++ b/src/rag/retrieval/vdb.py
@@ -138,6 +138,57 @@ class VectorDB:
         responses = [self.content[i] for i in top_k_indices]
         return responses
 
+    def delete(self, filter_criteria: Dict[str, str]) -> int:
+        """
+        Delete chunks that match ALL filter criteria.
+
+        Parameters:
+        - filter_criteria (Dict[str, str]): Dictionary of field:value pairs to match.
+          All criteria must match for a chunk to be deleted.
+
+        Returns:
+        - int: Number of chunks deleted.
+        """
+        if not filter_criteria:
+            return 0
+
+        if self.embeddings is None or not self.content:
+            return 0
+
+        # Find indices to keep (inverse of indices to delete)
+        indices_to_keep = []
+        for i, chunk_dict in enumerate(self.content):
+            # Check if this chunk matches ALL filter criteria
+            matches = all(
+                chunk_dict.get(key) == value for key, value in filter_criteria.items()
+            )
+            if not matches:
+                indices_to_keep.append(i)
+
+        deleted_count = len(self.content) - len(indices_to_keep)
+
+        if deleted_count == 0:
+            return 0
+
+        # Update content list
+        self.content = [self.content[i] for i in indices_to_keep]
+
+        # Update embeddings array
+        if MLX_AVAILABLE:
+            if indices_to_keep:
+                self.embeddings = self.embeddings[mx.array(indices_to_keep)]
+            else:
+                # All chunks deleted
+                self.embeddings = None
+        else:
+            if indices_to_keep:
+                self.embeddings = self.embeddings[indices_to_keep]
+            else:
+                # All chunks deleted
+                self.embeddings = None
+
+        return deleted_count
+
     def savez(self, vdb_file) -> None:
         target = Path(vdb_file)
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/rag/test_delete.py
+++ b/tests/rag/test_delete.py
@@ -1,0 +1,111 @@
+"""Tests for VectorDB deletion functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rag.retrieval.vdb import VectorDB
+
+
+def test_delete_by_source(tmp_path: Path):
+    """Test deleting chunks by source document name."""
+    vdb = VectorDB()
+    vdb.ingest("Apples are rich in fiber and vitamins.", "doc_apples.txt")
+    vdb.ingest("Bananas provide potassium and quick energy.", "doc_bananas.txt")
+
+    # Verify both documents are present
+    assert len(vdb.content) > 0
+    sources = {chunk["source"] for chunk in vdb.content}
+    assert "doc_apples.txt" in sources
+    assert "doc_bananas.txt" in sources
+
+    # Delete one document
+    deleted_count = vdb.delete({"source": "doc_apples.txt"})
+    assert deleted_count > 0
+
+    # Verify deletion
+    remaining_sources = {chunk["source"] for chunk in vdb.content}
+    assert "doc_apples.txt" not in remaining_sources
+    assert "doc_bananas.txt" in remaining_sources
+
+    # Query should never return deleted document
+    results = vdb.query("apples fiber", k=10)
+    for chunk in results:
+        assert chunk["source"] != "doc_apples.txt", "Deleted document should not be in results"
+
+
+def test_delete_persists_to_disk(tmp_path: Path):
+    """Test that deletions persist when saved and reloaded."""
+    vdb = VectorDB()
+    vdb.ingest("Apples are rich in fiber and vitamins.", "doc_apples.txt")
+    vdb.ingest("Bananas provide potassium and quick energy.", "doc_bananas.txt")
+
+    out_path = tmp_path / "demo" / "vdb.npz"
+    vdb.savez(out_path)
+
+    # Reload and delete
+    reloaded = VectorDB(str(out_path))
+    deleted_count = reloaded.delete({"source": "doc_apples.txt"})
+    assert deleted_count > 0
+
+    # Save again
+    reloaded.savez(out_path)
+
+    # Reload again and verify deletion persisted
+    final = VectorDB(str(out_path))
+    sources = {chunk["source"] for chunk in final.content}
+    assert "doc_apples.txt" not in sources
+    assert "doc_bananas.txt" in sources
+
+
+def test_delete_nonexistent_source():
+    """Test deleting with filter that matches nothing."""
+    vdb = VectorDB()
+    vdb.ingest("Apples are rich in fiber and vitamins.", "doc_apples.txt")
+
+    deleted_count = vdb.delete({"source": "nonexistent.txt"})
+    assert deleted_count == 0
+    assert len(vdb.content) > 0  # Original content unchanged
+
+
+def test_delete_empty_filter():
+    """Test that empty filter criteria returns 0 deletions."""
+    vdb = VectorDB()
+    vdb.ingest("Apples are rich in fiber and vitamins.", "doc_apples.txt")
+
+    deleted_count = vdb.delete({})
+    assert deleted_count == 0
+    assert len(vdb.content) > 0  # Original content unchanged
+
+
+def test_delete_all_chunks():
+    """Test deleting all chunks from the database."""
+    vdb = VectorDB()
+    vdb.ingest("Apples are rich in fiber and vitamins.", "doc_apples.txt")
+
+    initial_count = len(vdb.content)
+    assert initial_count > 0
+
+    deleted_count = vdb.delete({"source": "doc_apples.txt"})
+    assert deleted_count == initial_count
+
+    # Verify database is empty
+    assert len(vdb.content) == 0
+    assert vdb.embeddings is None
+
+
+def test_delete_with_multiple_criteria():
+    """Test deleting with multiple filter criteria (all must match)."""
+    vdb = VectorDB()
+    # Note: Currently chunks only have "text" and "source" fields
+    vdb.ingest("Apples are rich in fiber and vitamins.", "doc_apples.txt")
+    vdb.ingest("Bananas provide potassium and quick energy.", "doc_bananas.txt")
+
+    # This should match nothing because "source" doesn't match both
+    deleted_count = vdb.delete({"source": "doc_apples.txt", "text": "Bananas"})
+    assert deleted_count == 0
+
+    # All chunks should remain
+    assert len(vdb.content) > 0


### PR DESCRIPTION
- Add VectorDB.delete() method to remove chunks by filter criteria
- Implement filter-based deletion with exact string matching (AND logic)
- Update /delete API endpoint from stub to working implementation
- Persist deletions to .npz file atomically
- Handle edge cases: empty DB, no matches, delete all chunks
- Add comprehensive test suite (6 tests) in tests/rag/test_delete.py
- Verify stats() automatically reflects deletions
- No regressions in existing VectorDB tests

Resolves TASK 1 of Phase 02 - Delete support for RAG engine