### PR TITLE
Implement Real Cosine Similarity Scoring

### DIFF
--- a/src/rag/retrieval/vdb.py
+++ b/src/rag/retrieval/vdb.py
@@ -120,19 +120,77 @@ class VectorDB:
         for chunk in chunks:
             self.content.append({"text": chunk, "source": document_name})
 
+    def score(self, query_vec, doc_vec) -> float:
+        """
+        Compute cosine similarity between query and document vectors.
+
+        Parameters:
+        - query_vec: Query embedding vector (mx.array or np.array, float32)
+        - doc_vec: Document embedding vector (mx.array or np.array, float32)
+
+        Returns:
+        - float: Cosine similarity score in range [-1, 1]
+        """
+        if MLX_AVAILABLE:
+            # Ensure vectors are float32
+            query_vec = query_vec.astype(mx.float32)
+            doc_vec = doc_vec.astype(mx.float32)
+
+            # Compute cosine similarity: dot(a,b) / (||a|| * ||b|| + epsilon)
+            dot_product = mx.dot(query_vec, doc_vec)
+            query_norm = mx.linalg.norm(query_vec)
+            doc_norm = mx.linalg.norm(doc_vec)
+
+            # Add epsilon to avoid division by zero
+            epsilon = 1e-8
+            similarity = dot_product / (query_norm * doc_norm + epsilon)
+
+            # Return as Python float
+            return float(similarity.item())
+        else:
+            # Numpy fallback
+            query_vec = query_vec.astype(np.float32)
+            doc_vec = doc_vec.astype(np.float32)
+
+            dot_product = np.dot(query_vec, doc_vec)
+            query_norm = np.linalg.norm(query_vec)
+            doc_norm = np.linalg.norm(doc_vec)
+
+            epsilon = 1e-8
+            similarity = dot_product / (query_norm * doc_norm + epsilon)
+
+            return float(similarity)
+
     def query(self, text: str, k: int = 3) -> List[Dict[str, str]]:
         if self.embeddings is None:
             return []
         query_emb = self.model.run(text)
 
+        # Compute cosine similarity scores for all documents
+        scores = []
         if MLX_AVAILABLE:
-            scores = mx.matmul(query_emb, self.embeddings.T) * 100
-            sorted_indices = mx.argsort(scores, axis=1)
-            top_k_indices = sorted_indices[:, ::-1][:, :k].flatten().tolist()
+            query_vec = query_emb[0]  # Extract first row (single query)
+            for i in range(self.embeddings.shape[0]):
+                doc_vec = self.embeddings[i]
+                score = self.score(query_vec, doc_vec)
+                scores.append(score)
         else:
-            scores = np.matmul(query_emb, self.embeddings.T) * 100
-            sorted_indices = np.argsort(scores, axis=1)
-            top_k_indices = sorted_indices[:, ::-1][:, :k].flatten().tolist()
+            # Fallback for non-MLX (using numpy)
+            query_vec = query_emb[0]
+            for i in range(self.embeddings.shape[0]):
+                doc_vec = self.embeddings[i]
+                # Compute cosine similarity using numpy
+                dot_product = np.dot(query_vec, doc_vec)
+                query_norm = np.linalg.norm(query_vec)
+                doc_norm = np.linalg.norm(doc_vec)
+                score = dot_product / (query_norm * doc_norm + 1e-8)
+                scores.append(float(score))
+
+        # Sort indices by score in descending order (most similar first)
+        sorted_indices = sorted(range(len(scores)), key=lambda i: scores[i], reverse=True)
+
+        # Get top k results
+        top_k_indices = sorted_indices[:k]
 
         # Return the list of content dictionaries
         responses = [self.content[i] for i in top_k_indices]

--- a/tests/rag/conftest.py
+++ b/tests/rag/conftest.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Iterable, Sequence
 
-import mlx.core as mx
 import pytest
+
+try:
+    import mlx.core as mx
+    MLX_AVAILABLE = True
+except (ImportError, OSError):
+    # MLX not available or shared library missing - use numpy fallback
+    import numpy as np
+    MLX_AVAILABLE = False
 
 
 def _text_to_vector(text: str) -> list[float]:
@@ -22,14 +29,17 @@ def _text_to_vector(text: str) -> list[float]:
 class _StubModel:
     """Deterministic embedding stub so tests do not hit HuggingFace downloads."""
 
-    def run(self, input_text: str | Sequence[str]) -> mx.array:
+    def run(self, input_text: str | Sequence[str]):
         texts: Iterable[str]
         if isinstance(input_text, str):
             texts = [input_text]
         else:
             texts = input_text
         vectors = [_text_to_vector(t) for t in texts]
-        return mx.array(vectors, dtype=mx.float32)
+        if MLX_AVAILABLE:
+            return mx.array(vectors, dtype=mx.float32)
+        else:
+            return np.array(vectors, dtype=np.float32)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/rag/test_similarity.py
+++ b/tests/rag/test_similarity.py
@@ -1,0 +1,180 @@
+"""Tests for cosine similarity scoring in VectorDB."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import mlx.core as mx
+    MLX_AVAILABLE = True
+except (ImportError, OSError):
+    import numpy as np
+    MLX_AVAILABLE = False
+
+from rag.retrieval.vdb import VectorDB
+
+
+def _array(data, dtype=None):
+    """Helper to create arrays using available library."""
+    if MLX_AVAILABLE:
+        if dtype is None:
+            dtype = mx.float32
+        return mx.array(data, dtype=dtype)
+    else:
+        if dtype is None:
+            dtype = np.float32
+        return np.array(data, dtype=dtype)
+
+
+def test_identical_vectors_score_one():
+    """Identical vectors should have cosine similarity ≈ 1.0."""
+    vdb = VectorDB()
+
+    # Create identical vectors
+    vec1 = _array([1.0, 2.0, 3.0, 4.0])
+    vec2 = _array([1.0, 2.0, 3.0, 4.0])
+
+    score = vdb.score(vec1, vec2)
+
+    assert isinstance(score, float), "score() should return a Python float"
+    assert abs(score - 1.0) < 1e-6, f"Expected score ≈ 1.0, got {score}"
+
+
+def test_orthogonal_vectors_score_zero():
+    """Orthogonal (perpendicular) vectors should have cosine similarity ≈ 0.0."""
+    vdb = VectorDB()
+
+    # Create orthogonal vectors in 4D space
+    # vec1 = [1, 0, 0, 0] and vec2 = [0, 1, 0, 0] are orthogonal
+    vec1 = _array([1.0, 0.0, 0.0, 0.0])
+    vec2 = _array([0.0, 1.0, 0.0, 0.0])
+
+    score = vdb.score(vec1, vec2)
+
+    assert isinstance(score, float), "score() should return a Python float"
+    assert abs(score - 0.0) < 1e-6, f"Expected score ≈ 0.0, got {score}"
+
+
+def test_opposite_vectors_score_negative_one():
+    """Opposite (antiparallel) vectors should have cosine similarity ≈ -1.0."""
+    vdb = VectorDB()
+
+    # Create opposite vectors
+    vec1 = _array([1.0, 2.0, 3.0, 4.0])
+    vec2 = _array([-1.0, -2.0, -3.0, -4.0])
+
+    score = vdb.score(vec1, vec2)
+
+    assert isinstance(score, float), "score() should return a Python float"
+    assert abs(score - (-1.0)) < 1e-6, f"Expected score ≈ -1.0, got {score}"
+
+
+def test_partial_similarity():
+    """Partially similar vectors should have score between 0 and 1."""
+    vdb = VectorDB()
+
+    # Create vectors with partial similarity
+    vec1 = _array([1.0, 0.0, 0.0, 0.0])
+    vec2 = _array([1.0, 1.0, 0.0, 0.0])
+
+    score = vdb.score(vec1, vec2)
+
+    assert isinstance(score, float), "score() should return a Python float"
+    assert 0.0 < score < 1.0, f"Expected score between 0 and 1, got {score}"
+    # For these specific vectors, cosine similarity should be 1/sqrt(2) ≈ 0.707
+    expected = 1.0 / (2.0 ** 0.5)
+    assert abs(score - expected) < 1e-6, f"Expected score ≈ {expected}, got {score}"
+
+
+def test_zero_vector_handling():
+    """Zero vectors should be handled gracefully with epsilon."""
+    vdb = VectorDB()
+
+    # Create a zero vector and a normal vector
+    vec1 = _array([0.0, 0.0, 0.0, 0.0])
+    vec2 = _array([1.0, 2.0, 3.0, 4.0])
+
+    # Should not raise an error due to epsilon
+    score = vdb.score(vec1, vec2)
+
+    assert isinstance(score, float), "score() should return a Python float"
+    # With epsilon, this should be close to 0 but not raise division by zero
+    assert abs(score) < 1.0, "Score should be finite and small"
+
+
+def test_query_integration_with_cosine_similarity():
+    """VectorDB.query() should use cosine similarity and return most similar chunks first."""
+    vdb = VectorDB()
+
+    # Ingest documents with different content
+    vdb.ingest("The quick brown fox jumps over the lazy dog", "doc1.txt")
+    vdb.ingest("Apples are rich in fiber and vitamins", "doc2.txt")
+    vdb.ingest("The quick brown cat sleeps on the mat", "doc3.txt")
+
+    # Query with text similar to doc1 and doc3 (both have "quick brown")
+    results = vdb.query("quick brown", k=3)
+
+    # Should get results
+    assert len(results) > 0, "Expected query to return results"
+    assert len(results) <= 3, "Expected at most k=3 results"
+
+    # All results should have required fields
+    for result in results:
+        assert "text" in result, "Result should have 'text' field"
+        assert "source" in result, "Result should have 'source' field"
+
+
+def test_query_returns_descending_similarity():
+    """VectorDB.query() should return results in descending order of similarity."""
+    vdb = VectorDB()
+
+    # Ingest multiple documents
+    vdb.ingest("Machine learning is a subset of artificial intelligence", "ml.txt")
+    vdb.ingest("Python is a popular programming language", "python.txt")
+    vdb.ingest("Deep learning uses neural networks for pattern recognition", "dl.txt")
+
+    # Query
+    results = vdb.query("artificial intelligence machine learning", k=3)
+
+    assert len(results) > 0, "Expected query to return results"
+
+    # Manually compute scores to verify ordering
+    query_emb = vdb.model.run("artificial intelligence machine learning")
+    query_vec = query_emb[0]
+
+    result_scores = []
+    for result in results:
+        # Find the embedding for this result
+        for i, content in enumerate(vdb.content):
+            if content["text"] == result["text"] and content["source"] == result["source"]:
+                doc_vec = vdb.embeddings[i]
+                score = vdb.score(query_vec, doc_vec)
+                result_scores.append(score)
+                break
+
+    # Verify scores are in descending order
+    for i in range(len(result_scores) - 1):
+        assert result_scores[i] >= result_scores[i + 1], \
+            f"Scores should be descending: {result_scores[i]} >= {result_scores[i + 1]}"
+
+
+def test_score_with_stub_model_embeddings():
+    """Test that score() works correctly with StubModel embeddings."""
+    vdb = VectorDB()
+
+    # Use StubModel (via fixture) to generate embeddings
+    text1 = "Hello world"
+    text2 = "Hello world"
+    text3 = "Goodbye moon"
+
+    emb1 = vdb.model.run(text1)
+    emb2 = vdb.model.run(text2)
+    emb3 = vdb.model.run(text3)
+
+    # Identical text should have identical embeddings → score = 1.0
+    score_identical = vdb.score(emb1[0], emb2[0])
+    assert abs(score_identical - 1.0) < 1e-6, f"Expected score ≈ 1.0 for identical text, got {score_identical}"
+
+    # Different text should have different embeddings → score < 1.0
+    score_different = vdb.score(emb1[0], emb3[0])
+    assert score_different < 1.0, f"Expected score < 1.0 for different text, got {score_different}"


### PR DESCRIPTION
Replace stubbed similarity scorer with MLX-based cosine similarity implementation using dot product and L2 norms. Query results now ranked by descending similarity score.

- Add VectorDB.score() method with MLX/numpy dual support
- Implement cosine similarity: dot(a,b) / (||a|| * ||b|| + ε)
- Update query() to compute and sort by real similarity scores
- Add 8 comprehensive tests for similarity edge cases
- Ensure cross-platform compatibility with graceful MLX fallback

All 17 tests passing. No breaking changes to persistence format.